### PR TITLE
Add Sweepbase to Personal Financial Management

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,6 +149,7 @@ Curated list of awesome Fintech startup companies. If you'd like to have a compa
 - [SpendNode](https://www.spendnode.io/) [B2C] - Independent crypto card reviews, issuer coverage, country guides, and market updates.
 - [Smart Asset](https://smartasset.com/) [B2C, [@smartasset](https://twitter.com/smartasset), [LinkedIn](https://www.linkedin.com/company/smartasset-com/), [Careers](https://smartasset.com/careers)] - An award-winning NYC-based financial technology company that helps millions of people make smart financial decisions.
 - [PopaDex](https://popadex.com/) [B2C, [@popadex_finance](https://x.com/popadex_finance), [Linkedin](https://www.linkedin.com/company/popadex/)] - Your Net Worth, Tracked
+- [Sweepbase](https://sweepbase.net/) [B2C] - Crypto debit and credit card aggregator comparing 139 cards by real fees across regions.
 
 ## Business Financial Management
 


### PR DESCRIPTION
## Summary

Adds [Sweepbase](https://sweepbase.net/) to the **Personal Financial Management** section.

Sweepbase is a free aggregator comparing 139 crypto debit and credit cards across regions (USA, EU, UK, LATAM, Asia). It normalizes real-world fee structures — FX spread, ATM charges, staking requirements, annual fees, cashback tiers — so users can compare issuers without relying on marketing numbers.

It sits in the same category as **SpendNode** (already in this section), complementing it with a larger card dataset and a calculator for spend-specific cost comparisons.

## Disclosure

I maintain Sweepbase. The tool is free with no paywall or lead capture. Happy to adjust the description or entry format per maintainer preference.

## Checklist

- [x] Link active
- [x] Short objective description
- [x] No duplicate of existing entries (complements SpendNode)
- [x] Single entry