### PR TITLE
Add Base Pay Desk

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,6 +105,7 @@ Curated list of awesome Fintech startup companies. If you'd like to have a compa
 
 ## Payments & Billing
 
+- [Base Pay Desk](https://oskarasi.github.io/base-pay-desk-site/) [B2SMB, [GitHub](https://github.com/oskarasi/base-pay-desk-site)] - Independent ETH-on-Base checkout/link builder for creators, agencies, and service sellers; creates shareable payment links with visible fee math and no custody.
 - [BillGO](https://www.billgo.com/) [B2B, [@BillGOPayments](https://twitter.com/BillGOPayments), [LinkedIn](https://www.linkedin.com/company/billgopayments/), [Careers](https://www.billgo.com/join-us)] - BillGO facilitates a better financial future for everyone by combining the power of speed, choice and intelligence.
 - [Bolt](https://www.bolt.com/) [B2SMB, [@bolt](https://twitter.com/bolt), [LinkedIn](https://www.linkedin.com/company/bolt-com/), [Careers](https://www.bolt.com/careers/)] - We’re democratizing commerce
 - [Bread Financial](https://www.breadfinancial.com/) [B2B, [@BreadFinancial](https://twitter.com/BreadFinancial), [LinkedIn](https://www.linkedin.com/company/bread-financial/), [Careers](https://www.breadfinancial.com/en/who-we-are/careers.html)] - Bread Financial provides simple, personalized payment, lending and saving solutions


### PR DESCRIPTION
Adds Base Pay Desk to Payments & Billing.

Base Pay Desk is a live independent ETH-on-Base checkout/link builder for creators, agencies, and service sellers. It creates shareable payment links with visible fee math and no custody.

Evidence:
- Live app: https://oskarasi.github.io/base-pay-desk-site/
- Public repo: https://github.com/oskarasi/base-pay-desk-site
- Latest release: https://github.com/oskarasi/base-pay-desk-site/releases/tag/v0.1.43
- Current proof: v0.1.43 adds a lower-friction 0.005 ETH checkout-link review path alongside the full setup flow.

Caveat: this is an early public beta project/tool, not claiming customer traction or affiliation with Base, Coinbase, or official Base Pay.