### PR TITLE
Add Tapetide to Capital Markets

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@ Curated list of awesome Fintech startup companies. If you'd like to have a compa
 - [Trumid](https://www.trumid.com/) [B2B, [LinkedIn](https://www.linkedin.com/company/trumid/), [Careers](https://www.trumid.com/careers/)] - Fixed income trading platform
 - [Yieldstreet](https://www.yieldstreet.com/) [B2C, [@Yieldstreet](https://twitter.com/Yieldstreet), [LinkedIn](https://www.linkedin.com/company/yieldstreet-inc/), [Careers](https://jobs.lever.co/yieldstreet)] - Yieldstreet provides individuals with alternative investments in asset classes like art, real estate, legal and finance traditionally reserved for institutions.
 - [InvicTrade](https://invictrade.com) [B2C] - AI-powered trading signals with 74% historical win rate, combining strategies from legendary investors using multi-model AI intelligence.
+- [Tapetide](https://tapetide.com) [B2C] - AI-first stock research platform for Indian markets, covering all 8,200+ NSE and BSE stocks with quotes, financials, a 326-ratio screener, FII/DII institutional flows, and an MCP server for AI agents.
 
 ## Digital Assets & Blockchain
 


### PR DESCRIPTION
Adds **Tapetide** to the **Capital Markets** section (appended to the bottom, following the existing `[Name](url) [B2C] - Description` format).

`- [Tapetide](https://tapetide.com) [B2C] - AI-first stock research platform for Indian markets, covering all 8,200+ NSE and BSE stocks with quotes, financials, a 326-ratio screener, FII/DII institutional flows, and an MCP server for AI agents.`

Tapetide is a fintech product offering AI-powered research across every NSE & BSE listed stock, plus a public API and MCP server. Proof-read, no duplicate, follows awesome-list guidelines.