### PR TITLE
Add QuantLink to Capital Markets

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@ Curated list of awesome Fintech startup companies. If you'd like to have a compa
 - [Tapetide](https://tapetide.com) [B2C] - AI-first stock research platform for Indian markets, covering all 8,200+ NSE and BSE stocks with quotes, financials, a 326-ratio screener, FII/DII institutional flows, and an MCP server for AI agents.
 - [Insider Alerts](https://insideralerts.io/) [B2C] - SEC Form 4 insider trading alerts, watchlists, and searchable insider buying and selling activity for investors.
 - [PolyMind](https://polyminds.netlify.app/) [B2C] - Real-time Polymarket trading alerts with multi-AI analysis (Groq, Claude, Gemini). Track whale bets, volume spikes, coordinated wallets, and 12 signal types. Free tier available.
+- [QuantLink](https://www.quantlink.ai) [B2C] - AI-powered US-equity research terminal with a stock screener, AI deep-research on SEC filings, institutional 13F holder analysis, insider (Form 4) activity, and congressional trade tracking. Free tier available.
 
 ## Digital Assets & Blockchain
 


### PR DESCRIPTION
Adds one entry for **QuantLink** (https://www.quantlink.ai) to the **Capital Markets** section.

QuantLink is an AI-powered US-equity research terminal: a stock screener, AI deep-research on SEC filings, institutional 13F holder analysis, insider (Form 4) activity, and congressional trade tracking. Free tier available.

It fits Capital Markets next to comparable research/analytics companies already listed there, such as Tapetide (AI-first stock research), 13F Insight, and Insider Alerts.

- One entry, added at the end of the section, format matches surrounding entries (`[B2C]`).
- Not a duplicate.
- Website is live and https.

Made with [Cursor](https://cursor.com)