### PR TITLE
Add Nutilz Mortgage Affordability Calculator to Personal Financial Management

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,6 +170,7 @@ Curated list of awesome Fintech startup companies. If you'd like to have a compa
 - [IndepAI](https://indepai.app/) [B2C] - Free FIRE calculators (Coast FIRE, Barista FIRE, FI score) and cost-of-living data for 11,400+ cities, built for digital nomads planning geo-arbitrage.
 - [Sweepbase](https://sweepbase.net/) [B2C] - Crypto debit and credit card aggregator comparing 139 cards by real fees across regions.
 - [Nutilz Discount Calculator](https://nutilz.com/discount-calculator) [B2C] - Free browser-based calculator for working out sale prices, discount percentages, and stacked/multiple discounts — no signup required.
+- [Nutilz Mortgage Affordability Calculator](https://nutilz.com/mortgage-affordability-calculator) [B2C] - Free browser-based calculator estimating how much house you can afford based on income, debts, down payment, and interest rate — no signup required.
 
 ## Business Financial Management
 


### PR DESCRIPTION
Adds Nutilz Mortgage Affordability Calculator (https://nutilz.com/mortgage-affordability-calculator) to the Personal Financial Management section, alongside the existing Nutilz Discount Calculator entry.

Free, browser-based tool that estimates how much house a user can afford based on income, debts, down payment, and interest rate. No signup required.