### PR TITLE
Add Nutilz Inflation Calculator to Personal Financial Management

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,6 +170,7 @@ Curated list of awesome Fintech startup companies. If you'd like to have a compa
 - [IndepAI](https://indepai.app/) [B2C] - Free FIRE calculators (Coast FIRE, Barista FIRE, FI score) and cost-of-living data for 11,400+ cities, built for digital nomads planning geo-arbitrage.
 - [Sweepbase](https://sweepbase.net/) [B2C] - Crypto debit and credit card aggregator comparing 139 cards by real fees across regions.
 - [Nutilz Discount Calculator](https://nutilz.com/discount-calculator) [B2C] - Free browser-based calculator for working out sale prices, discount percentages, and stacked/multiple discounts — no signup required.
+- [Nutilz Inflation Calculator](https://nutilz.com/inflation-calculator) [B2C] - Free browser-based calculator using real historical CPI data to show what money in one year is worth in another — no signup required.
 
 ## Business Financial Management
 


### PR DESCRIPTION
Adds Nutilz Inflation Calculator (https://nutilz.com/inflation-calculator) to the Personal Financial Management section — a free, browser-based calculator using real historical CPI data, no signup required. Same author/site as the existing Nutilz Discount Calculator entry already listed in this section.