### PR TITLE
Add Nutilz Stock Profit Calculator to Personal Financial Management

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,6 +170,7 @@ Curated list of awesome Fintech startup companies. If you'd like to have a compa
 - [IndepAI](https://indepai.app/) [B2C] - Free FIRE calculators (Coast FIRE, Barista FIRE, FI score) and cost-of-living data for 11,400+ cities, built for digital nomads planning geo-arbitrage.
 - [Sweepbase](https://sweepbase.net/) [B2C] - Crypto debit and credit card aggregator comparing 139 cards by real fees across regions.
 - [Nutilz Discount Calculator](https://nutilz.com/discount-calculator) [B2C] - Free browser-based calculator for working out sale prices, discount percentages, and stacked/multiple discounts — no signup required.
+- [Nutilz Stock Profit Calculator](https://nutilz.com/stock-profit-calculator) [B2C] - Free browser-based calculator for stock trade profit, total return %, and annualized CAGR — enter buy/sell price, shares, commissions and dividends, no signup required.
 
 ## Business Financial Management
 


### PR DESCRIPTION
Adds Nutilz Stock Profit Calculator (https://nutilz.com/stock-profit-calculator) to the Personal Financial Management section.

A free, browser-based calculator for stock trade profit, total return %, and annualized CAGR — enter buy/sell price, shares, commissions, and dividends to instantly see net profit/loss and return metrics. No signup required.